### PR TITLE
Removed United Kingdom from list of EU countries, also known as Brexit

### DIFF
--- a/lib/Locale/Country/EU.pm
+++ b/lib/Locale/Country/EU.pm
@@ -105,12 +105,6 @@ our $EU_COUNTRY_MAP = [
         'ISO-alpha2' => 'SE',
     },
     {
-        'ISO-name'   => 'United Kingdom',
-        'ISO-m49'    => '826',
-        'ISO-alpha3' => 'GBR',
-        'ISO-alpha2' => 'GB',
-    },
-    {
         'ISO-name'   => 'Croatia',
         'ISO-m49'    => '191',
         'ISO-alpha3' => 'HRV',


### PR DESCRIPTION
I am the maintainer of Business::Tax::VAT, I just implemented Brexit for this distribution. I was looking for a country code module to assist me with maintaining the EU member states and I fell over this one, which I might put to use.

Take care and stay safe,

jonasbn